### PR TITLE
Fix: Unpad failed if buffer length equal to block size

### DIFF
--- a/padding/example_test.go
+++ b/padding/example_test.go
@@ -87,3 +87,17 @@ func ExamplePadder_Unpad_third() {
 	// 0A0B0C0D0C0C0C0C0C0C0C0C0C0C0C0C
 	// 0A0B0C0D
 }
+
+func ExamplePadder_Unpad_empty() {
+	p := []byte{0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08}
+	fmt.Printf("%X\n", p)
+	padder := NewPkcs7Padding(8) // 8-byte block size
+	p, err := padder.Unpad(p)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%v\n", p)
+	// Output:
+	// 0808080808080808
+	// []
+}

--- a/padding/padding.go
+++ b/padding/padding.go
@@ -67,7 +67,7 @@ func (p *Padder) Pad(buf []byte) ([]byte, error) {
 func (p *Padder) Unpad(buf []byte) ([]byte, error) {
 	bufLen := len(buf)
 	padLen := int(buf[bufLen-1])
-	if padLen >= bufLen || padLen > p.blockSize {
+	if padLen > bufLen || padLen > p.blockSize {
 		return nil, errors.New("cryptgo/padding: invalid padding size")
 	}
 	return buf[:bufLen-padLen], nil

--- a/padding/padding.go
+++ b/padding/padding.go
@@ -66,9 +66,21 @@ func (p *Padder) Pad(buf []byte) ([]byte, error) {
 // 	[]byte{0x0A, 0x0B, 0x0C, 0x0D}
 func (p *Padder) Unpad(buf []byte) ([]byte, error) {
 	bufLen := len(buf)
-	padLen := int(buf[bufLen-1])
+	if bufLen == 0 {
+		return nil, errors.New("cryptgo/padding: invalid padding size")
+	}
+
+	pad := buf[bufLen-1]
+	padLen := int(pad)
 	if padLen > bufLen || padLen > p.blockSize {
 		return nil, errors.New("cryptgo/padding: invalid padding size")
 	}
+
+	for _, v := range buf[bufLen-padLen : bufLen-1] {
+		if v != pad {
+			return nil, errors.New("cryptgo/padding: invalid padding")
+		}
+	}
+
 	return buf[:bufLen-padLen], nil
 }


### PR DESCRIPTION
Pad an empty buffer, will get a padding of one block size, such as 0x04040404 if block size is 4.
It should unpad to empty []byte.

See ExamplePadder_Unpad_empty()