### PR TITLE
use go modules

### DIFF
--- a/ecb/go.mod
+++ b/ecb/go.mod
@@ -1,0 +1,3 @@
+module "https://github.com/andreburgaud/crypt2go/ecb"
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/andreburgaud/crypt2go
+
+go 1.12

--- a/padding/go.mod
+++ b/padding/go.mod
@@ -1,0 +1,3 @@
+module "https://github.com/andreburgaud/crypt2go/padding"
+
+go 1.12


### PR DESCRIPTION
I like the repo, but need it to be versioned since I will be using this in a production environment. All you would need to do is to create a release with v1.0.0 as version and name for this to be fully utilized by `go get` using Go Modules (a >= Go 1.11 feature)